### PR TITLE
Update Updater.php to merge before and after update pipelines with existing pipelines

### DIFF
--- a/src/Updater.php
+++ b/src/Updater.php
@@ -58,7 +58,7 @@ class Updater
                 ];
 
                 if (config('updater.before_update_pipelines', false) && is_array(config('updater.before_update_pipelines')) && count(config('updater.before_update_pipelines')) > 0) {
-                    $pipelines[] = config('updater.before_update_pipelines');
+                    $pipelines = array_merge($pipelines, config('updater.before_update_pipelines'));
                 }
 
                 if (config('updater.migrate', false)) {
@@ -90,7 +90,7 @@ class Updater
                 }
 
                 if (config('updater.after_update_pipelines', false) && is_array(config('updater.after_update_pipelines')) && count(config('updater.after_update_pipelines')) > 0) {
-                    $pipelines[] = config('updater.after_update_pipelines');
+                    $pipelines = array_merge($pipelines, config('updater.after_update_pipelines'));
                 }
 
                 // check if pipelines is array and not empty and items is implemented Pipeline contract

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -5,16 +5,16 @@ use Salahhusa9\Updater\Helpers\Helper;
 
 class HelperTest extends TestCase
 {
-    public function testIsVersionReturnsTrueForValidVersion()
+    public function test_is_version_returns_true_for_valid_version()
     {
-        $helper = new Helper();
+        $helper = new Helper;
 
         $this->assertEquals($helper->isVersion('v1.2.3'), 1);
     }
 
-    public function testIsVersionReturnsFalseForInvalidVersion()
+    public function test_is_version_returns_false_for_invalid_version()
     {
-        $helper = new Helper();
+        $helper = new Helper;
 
         $this->assertEqualsCanonicalizing($helper->isVersion('invalid-version'), 0);
     }

--- a/tests/RepositorySource/GithubRepositoryTest.php
+++ b/tests/RepositorySource/GithubRepositoryTest.php
@@ -16,7 +16,7 @@ class GithubRepositoryTest extends \Salahhusa9\Updater\Tests\TestCase
         config()->set('updater.github_username', 'salahhusa9');
         config()->set('updater.github_repository', 'laravel-updater');
 
-        $githubRepository = new GithubRepository();
+        $githubRepository = new GithubRepository;
 
         $this->assertTrue($githubRepository->checkConfig());
     }
@@ -26,7 +26,7 @@ class GithubRepositoryTest extends \Salahhusa9\Updater\Tests\TestCase
     {
         $this->expectException(GithubConfigException::class);
 
-        $githubRepository = new GithubRepository();
+        $githubRepository = new GithubRepository;
 
         $this->assertTrue($githubRepository->checkConfig());
     }
@@ -45,7 +45,7 @@ class GithubRepositoryTest extends \Salahhusa9\Updater\Tests\TestCase
             ], 200),
         ]);
 
-        $githubRepository = new GithubRepository();
+        $githubRepository = new GithubRepository;
 
         $this->assertEquals('v1.0.0', $githubRepository->getLatestVersion());
     }
@@ -64,7 +64,7 @@ class GithubRepositoryTest extends \Salahhusa9\Updater\Tests\TestCase
             ], 200),
         ]);
 
-        $githubRepository = new GithubRepository();
+        $githubRepository = new GithubRepository;
 
         $this->assertIsArray($githubRepository->getLatestVersionData()->toArray());
     }
@@ -88,7 +88,7 @@ class GithubRepositoryTest extends \Salahhusa9\Updater\Tests\TestCase
             ], 200),
         ]);
 
-        $githubRepository = new GithubRepository();
+        $githubRepository = new GithubRepository;
 
         $this->assertIsArray($githubRepository->getVersions());
     }
@@ -112,7 +112,7 @@ class GithubRepositoryTest extends \Salahhusa9\Updater\Tests\TestCase
             ], 200),
         ]);
 
-        $githubRepository = new GithubRepository();
+        $githubRepository = new GithubRepository;
 
         $this->assertIsArray($githubRepository->getVersionsData()->toArray());
     }

--- a/tests/UpdaterTest.php
+++ b/tests/UpdaterTest.php
@@ -9,7 +9,7 @@ use Salahhusa9\Updater\Tests\TestCase;
 
 class UpdaterTest extends TestCase
 {
-    public function testGetCurrentVersion()
+    public function test_get_current_version()
     {
         config()->set('updater.git_path', 'git');
 
@@ -21,7 +21,7 @@ class UpdaterTest extends TestCase
         $this->assertEquals('1.0.0', Updater::getCurrentVersion());
     }
 
-    public function testGetLatestVersion()
+    public function test_get_latest_version()
     {
         Http::fake([
             'https://api.github.com/repos/salahhusa9/laravel-test/releases/latest' => Http::response([
@@ -46,7 +46,7 @@ class UpdaterTest extends TestCase
         $this->assertEquals('1.0.1', Updater::getLatestVersion());
     }
 
-    public function testGetLatestVersionData()
+    public function test_get_latest_version_data()
     {
         Http::fake([
             'https://api.github.com/repos/salahhusa9/laravel-test/releases/latest' => Http::response([
@@ -71,7 +71,7 @@ class UpdaterTest extends TestCase
         $this->assertEquals(['tag_name' => '1.0.1'], Updater::getLatestVersionData());
     }
 
-    public function testVersions()
+    public function test_versions()
     {
         Http::fake([
             'https://api.github.com/repos/salahhusa9/laravel-test/releases' => Http::response([
@@ -104,7 +104,7 @@ class UpdaterTest extends TestCase
         $this->assertEquals(['1.0.0', '1.1.0', '2.0.0'], Updater::versions());
     }
 
-    public function testNewVersionAvailable()
+    public function test_new_version_available()
     {
         Http::fake([
             'https://api.github.com/repos/salahhusa9/laravel-test/releases/latest' => Http::response([
@@ -129,7 +129,7 @@ class UpdaterTest extends TestCase
         $this->assertEquals(['current_version' => '1.0.0', 'latest_version' => '1.0.1'], Updater::newVersionAvailable());
     }
 
-    public function testUpdate()
+    public function test_update()
     {
         Event::fake();
         // Artisan::fake();


### PR DESCRIPTION
This pull request includes changes to the `src/Updater.php` file to improve the handling of update pipelines. The most important changes are:

* Improved merging of pipeline configurations:
  * Modified the `updateTo` function to use `array_merge` for combining `before_update_pipelines` with existing pipelines.
  * Modified the `updateTo` function to use `array_merge` for combining `after_update_pipelines` with existing pipelines.