### PR TITLE
Update Laravel and PHP version requirements in composer.json and run-tests.yml

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: none
+          coverage: xdebug
 
       - name: Setup problem matchers
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         # php: [8.1, 8.2]
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -26,6 +26,9 @@ jobs:
           - laravel: 12.*
             testbench: 10.*
             php: 8.3
+          - laravel: 13.*
+            testbench: 11.*
+            php: 8.4
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,12 +14,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         # php: [8.1, 8.2]
-        laravel: [10.*, 11.*, 12.*, 13.*]
+        laravel: [11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
-            php: 8.1
           - laravel: 11.*
             testbench: 9.*
             php: 8.2

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.8|^8.0",
-        "orchestra/testbench": "11.1.0",
+        "orchestra/testbench": "^9.0|^10.0|^11.0|^12.0",
         "pestphp/pest": "^2.20|^2.35|^3.0|^4.0",
         "pestphp/pest-plugin-arch": "^2.0|^3.0|^4.0",
         "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0"

--- a/composer.json
+++ b/composer.json
@@ -22,19 +22,19 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2|^8.3|^8.4",
+        "php": "^8.2|^8.3|^8.4",
         "guzzlehttp/guzzle": "^7.8",
-        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.0",
         "symfony/process": "^6.3|^7.0|^8.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.8|^8.0",
-        "orchestra/testbench": "^9.17.0|^10.0|^11.0|^12.0",
-        "pestphp/pest": "^2.20|^2.35|^3.0|^4.0",
-        "pestphp/pest-plugin-arch": "^2.0|^3.0|^4.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0"
+        "orchestra/testbench": "^10.0|^11.0|^12.0",
+        "pestphp/pest": "^3.0|^4.0",
+        "pestphp/pest-plugin-arch": "^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.8|^8.0",
         "orchestra/testbench": "11.1.0",
-        "pestphp/pest": "^2.20|^3.0|^4.0",
+        "pestphp/pest": "^2.20|^2.35|^3.0|^4.0",
         "pestphp/pest-plugin-arch": "^2.0|^3.0|^4.0",
         "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.8|^8.0",
-        "orchestra/testbench": "^9.0|^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^9.17.0|^10.0|^11.0|^12.0",
         "pestphp/pest": "^2.20|^2.35|^3.0|^4.0",
         "pestphp/pest-plugin-arch": "^2.0|^3.0|^4.0",
         "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0"

--- a/composer.json
+++ b/composer.json
@@ -22,16 +22,16 @@
         }
     ],
     "require": {
-        "php": "^8.1|^8.2",
+        "php": "^8.1|^8.2|^8.3|^8.4",
         "guzzlehttp/guzzle": "^7.8",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "spatie/laravel-package-tools": "^1.0",
-        "symfony/process": "^6.3|^7.0"
+        "symfony/process": "^6.3|^7.0|^8.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.8|^8.0",
-        "orchestra/testbench": "10.1.0",
+        "orchestra/testbench": "11.1.0",
         "pestphp/pest": "^2.20|^3.0",
         "pestphp/pest-plugin-arch": "^2.0|^3.0",
         "pestphp/pest-plugin-laravel": "^2.0|^3.0"

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,9 @@
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.8|^8.0",
         "orchestra/testbench": "11.1.0",
-        "pestphp/pest": "^2.20|^3.0",
-        "pestphp/pest-plugin-arch": "^2.0|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.0"
+        "pestphp/pest": "^2.20|^3.0|^4.0",
+        "pestphp/pest-plugin-arch": "^2.0|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^2.0|^3.0|^4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request updates the project to support the latest versions of Laravel, PHP, and related dependencies. It also updates the test matrix to ensure compatibility with these new versions. The most important changes are:

**Dependency and Compatibility Updates:**

* Updated `composer.json` to support PHP 8.3 and 8.4, Laravel 13, and Symfony Process 8.0. This ensures the package can be used with the latest versions of these dependencies.
* Upgraded `orchestra/testbench` in `composer.json` to version 11.1.0 for compatibility with Laravel 13.

**CI/Test Matrix Updates:**

* Extended the GitHub Actions test matrix in `.github/workflows/run-tests.yml` to include Laravel 13, Testbench 11, and PHP 8.4, so automated tests are run against the latest supported versions. [[1]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L17-R17) [[2]](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642R29-R31)