### PR TITLE
Update README badge and remove renovate configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Laravel Updater
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/salahhusa9/laravel-updater.svg?style=flat-square)](https://packagist.org/packages/salahhusa9/laravel-updater)
-![laravel](https://img.shields.io/badge/Laravel-10%7C11%7C12-red)
+![laravel](https://img.shields.io/badge/Laravel-11%7C12%7C13-red)
 [![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/salahhusa9/laravel-updater/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/salahhusa9/laravel-updater/actions?query=workflow%3Arun-tests+branch%3Amain)
 [![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/salahhusa9/laravel-updater/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/salahhusa9/laravel-updater/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
 [![Total Downloads](https://img.shields.io/packagist/dt/salahhusa9/laravel-updater.svg?style=flat-square)](https://packagist.org/packages/salahhusa9/laravel-updater)

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "config:base"
-    ]
-}


### PR DESCRIPTION
This pull request makes two small changes: it updates the `README.md` badge to reflect support for newer Laravel versions, and it removes the `renovate.json` configuration file. These are minor maintenance updates.